### PR TITLE
fix: stabilize board row sizing

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -578,7 +578,7 @@ function App() {
   const isMyTurn = game.current_turn === myColor;
 
   // Prepare Render Board (Flip if Red)
-  let renderBoard = game.board;
+  const renderBoard = game.board;
   let displayBoard = [...renderBoard.map(r => [...r])]; 
   
   if (viewPerspective === "red") {
@@ -655,6 +655,7 @@ function App() {
           <div className={clsx("relative p-3 bg-stone-700 shadow-2xl transition-opacity duration-300 w-full aspect-square", !isMyTurn && "opacity-95")}>
               <div 
                 className="grid grid-cols-8 gap-0 border-4 border-[#5c4033] bg-[#5c4033] w-full h-full" 
+                style={{ gridTemplateRows: "repeat(8, minmax(0, 1fr))" }}
               >
                 {displayBoard.map((row, rIndex) => (
                 row.map((cell, cIndex) => {

--- a/fe/src/components/Square.tsx
+++ b/fe/src/components/Square.tsx
@@ -29,7 +29,7 @@ export const Square: React.FC<SquareProps> = ({
     <div
       onClick={onClick}
       className={clsx(
-        "w-full h-full flex items-center justify-center relative cursor-pointer transition-colors duration-200",
+        "w-full h-full flex items-center justify-center relative cursor-pointer transition-colors duration-200 overflow-hidden",
         isDark ? "bg-[#5c4033] hover:bg-[#6d4c3d]" : "bg-[#d2b48c] hover:bg-[#e6c9a3]", // Classic Wood Colors
         isSelected && "ring-inset ring-4 ring-yellow-400 bg-amber-900",
         (isLastMoveSource || isLastMoveDest) && "bg-yellow-500/40", // Highlight Last Move


### PR DESCRIPTION
## Summary
- Fixes an issue where board rows would change size based on piece placement by enforcing `gridTemplateRows` style.
- Adds `overflow-hidden` to squares to ensure pieces stay contained.
- Minor cleanup: changed `let` to `const` for `renderBoard`.