### PR TITLE
Refactor: Use Native Postgres Types (UUID, JSONB) & Safe Migrations

### DIFF
--- a/be/alembic/env.py
+++ b/be/alembic/env.py
@@ -19,27 +19,20 @@ from models import Base
 config = context.config
 
 # Set the database URL from our code
-# Ensure we use async driver
-if DATABASE_URL.startswith("postgresql://") and "asyncpg" not in DATABASE_URL:
-    final_url = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
-elif DATABASE_URL.startswith("postgres://"):
-    final_url = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://")
-else:
-    final_url = DATABASE_URL
-
-config.set_main_option("sqlalchemy.url", final_url)
+# DATABASE_URL is already processed in be/database.py to ensure asyncpg driver
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
 
 # Interpret the config file for Python logging.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 # Debug: Print DB URL (masked)
-masked_url = final_url
-if ":" in final_url and "@" in final_url:
+masked_url = DATABASE_URL
+if ":" in DATABASE_URL and "@" in DATABASE_URL:
     try:
         # Simple mask
-        prefix = final_url.split("://")[0]
-        suffix = final_url.split("@")[1]
+        prefix = DATABASE_URL.split("://")[0]
+        suffix = DATABASE_URL.split("@")[1]
         masked_url = f"{prefix}://****:****@{suffix}"
     except Exception:
         pass
@@ -96,7 +89,7 @@ async def run_async_migrations() -> None:
     section = config.get_section(config.config_ini_section)
     if section is None:
         raise ValueError("Alembic section not found in config")
-    section["sqlalchemy.url"] = final_url
+    section["sqlalchemy.url"] = DATABASE_URL
     
     connectable = async_engine_from_config(
         section,

--- a/be/alembic/versions/d4f405e5134b_convert_to_native_types.py
+++ b/be/alembic/versions/d4f405e5134b_convert_to_native_types.py
@@ -1,0 +1,66 @@
+"""convert_to_native_types
+
+Revision ID: d4f405e5134b
+Revises: 81e2fb85546d
+Create Date: 2026-02-20 23:22:01.027878
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4f405e5134b'
+down_revision: Union[str, Sequence[str], None] = '81e2fb85546d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Convert 'id' from String to UUID
+    # We use explicit casting with USING
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN id TYPE uuid USING id::uuid"
+    )
+
+    # 2. Convert 'board_state' from JSON to JSONB
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN board_state TYPE jsonb USING board_state::jsonb"
+    )
+    
+    # 3. Convert 'last_move' from JSON to JSONB
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN last_move TYPE jsonb USING last_move::jsonb"
+    )
+    
+    # 4. Convert 'active_piece' from JSON to JSONB
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN active_piece TYPE jsonb USING active_piece::jsonb"
+    )
+
+
+def downgrade() -> None:
+    # Reverse the operations
+    
+    # 1. Convert 'active_piece' back to JSON
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN active_piece TYPE json USING active_piece::json"
+    )
+
+    # 2. Convert 'last_move' back to JSON
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN last_move TYPE json USING last_move::json"
+    )
+
+    # 3. Convert 'board_state' back to JSON
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN board_state TYPE json USING board_state::json"
+    )
+    
+    # 4. Convert 'id' back to String
+    op.execute(
+        "ALTER TABLE games ALTER COLUMN id TYPE varchar USING id::text"
+    )

--- a/be/database.py
+++ b/be/database.py
@@ -2,13 +2,18 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sess
 from sqlalchemy.orm import DeclarativeBase
 import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5433/checkers_db")
+def get_database_url() -> str:
+    url = os.getenv("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5433/checkers_db")
+    
+    # Ensure we use the async driver if Fly.io provides a standard postgres:// URL
+    if url and url.startswith("postgres://"):
+        url = url.replace("postgres://", "postgresql+asyncpg://", 1)
+    elif url and url.startswith("postgresql://") and "asyncpg" not in url:
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    
+    return url
 
-# Ensure we use the async driver if Fly.io provides a standard postgres:// URL
-if DATABASE_URL and DATABASE_URL.startswith("postgres://"):
-    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
-elif DATABASE_URL and DATABASE_URL.startswith("postgresql://") and "asyncpg" not in DATABASE_URL:
-    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+DATABASE_URL = get_database_url()
 
 engine = create_async_engine(DATABASE_URL, echo=False)
 

--- a/be/main.py
+++ b/be/main.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import sys
+import subprocess
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -18,9 +20,24 @@ async def lifespan(app: FastAPI):
     # Suppress uvicorn access logs (200 OKs), keep errors
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
 
-    # Create tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    # Automatic Migration
+    # Run alembic upgrade head to ensure DB is up to date.
+    # We use subprocess to avoid async loop conflicts with alembic's env.py
+    # and ensure we use the same python environment.
+    #
+    # Default behavior: Run migrations (SKIP_MIGRATIONS_ON_STARTUP=false)
+    # Production override: SKIP_MIGRATIONS_ON_STARTUP=true (via fly.toml)
+    skip_migrations = os.getenv("SKIP_MIGRATIONS_ON_STARTUP", "false").lower() == "true"
+    is_testing = "pytest" in sys.modules
+
+    if not skip_migrations and not is_testing:
+        try:
+            subprocess.run([sys.executable, "-m", "alembic", "upgrade", "head"], check=True)
+            logging.info("Startup migrations executed successfully.")
+        except subprocess.CalledProcessError as e:
+            logging.error(f"Migration failed during startup: {e}")
+            # Fail startup if migrations fail to prevent running with broken schema
+            raise e
         
     # Initialize active games count
     async with engine.connect() as conn:

--- a/be/models.py
+++ b/be/models.py
@@ -1,17 +1,15 @@
-from sqlalchemy import String, JSON, Integer
+from sqlalchemy import String, Integer
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from database import Base
 import uuid
 from typing import Optional, List, Dict
 
-def generate_uuid():
-    return str(uuid.uuid4())
-
 class Game(Base):
     __tablename__ = "games"
 
-    id: Mapped[str] = mapped_column(String, primary_key=True, default=generate_uuid, index=True)
-    board_state: Mapped[List[List[Optional[str]]]] = mapped_column(JSON, nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    board_state: Mapped[List[List[Optional[str]]]] = mapped_column(JSONB, nullable=False)
     current_turn: Mapped[str] = mapped_column(String, default="red")
     status: Mapped[str] = mapped_column(String, default="active")
     winner: Mapped[Optional[str]] = mapped_column(String, nullable=True)
@@ -19,8 +17,8 @@ class Game(Base):
     black_player_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     red_player_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     black_player_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    last_move: Mapped[Optional[Dict[str, int]]] = mapped_column(JSON, nullable=True)
-    active_piece: Mapped[Optional[Dict[str, int]]] = mapped_column(JSON, nullable=True)
+    last_move: Mapped[Optional[Dict[str, int]]] = mapped_column(JSONB, nullable=True)
+    active_piece: Mapped[Optional[Dict[str, int]]] = mapped_column(JSONB, nullable=True)
     mode: Mapped[str] = mapped_column(String, default="online")
     draw_offer: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     draw_timer: Mapped[int] = mapped_column(Integer, default=0)

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,10 @@
 app = 'checkers-game-app'
 primary_region = 'lax'
 
+[env]
+  # Skip migrations on startup in production because we use release_command
+  SKIP_MIGRATIONS_ON_STARTUP = "true"
+
 [deploy]
   release_command = "alembic upgrade head"
 


### PR DESCRIPTION
## Summary
This PR modernizes the database schema and improves operational safety for both local development and production.

### Key Changes
1.  **Native PostgreSQL Types:**
    *   Converted `id` column from `String` to `UUID`.
    *   Converted `board_state`, `last_move`, and `active_piece` from `JSON` to `JSONB` for better performance and indexing capabilities.
    *   Added a manual migration script (`d4f405e5134b_convert_to_native_types.py`) with explicit `USING` clauses to ensure zero data loss during conversion.

2.  **Configuration Cleanup:**
    *   Centralized `DATABASE_URL` processing in `be/database.py` to remove redundant logic in `alembic/env.py`.
    *   Ensured `asyncpg` driver is consistently used.

3.  **Safe & Automatic Migrations:**
    *   **Local Dev:** Migrations now run automatically on startup (`be/main.py`), replacing the unsafe `Base.metadata.create_all`.
    *   **Testing:** Migrations are automatically skipped during `pytest` execution to improve speed and isolation.
    *   **Production:** Added `SKIP_MIGRATIONS_ON_STARTUP = "true"` to `fly.toml` to prevent redundant migration attempts on container startup (relying instead on the existing `release_command`).

### Verification
*   **Schema:** Verified locally with `psql` that columns are now `uuid` and `jsonb`.
*   **Tests:** `pytest` passes successfully (confirming migration skip logic works).
*   **Startup:** Local startup runs migrations as expected.